### PR TITLE
Fix lint failure by removing unused import

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -52,6 +52,7 @@
 - [x] Added a synthesis stage that orders assessed pages by prompt fit and technical depth, then prompts the LLM for a sourced final answer (October 3, 2025).
 - [x] Ensured console and JSON outputs list pages in the same relevance order used during final answer synthesis (October 3, 2025).
 - [x] Implemented a three-day page cache with an optional CLI refresh flag to skip cache hits when required (October 3, 2025).
+- [x] Removed an unused integration-test import flagged by CI linting to keep the suite clean (October 3, 2025).
 
 ## Next Steps
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,7 +21,7 @@ from scolar.models import (
     RecommendedLink,
     Score,
 )
-from scolar.pipeline import ProcessedPage, gather_pages
+from scolar.pipeline import gather_pages
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- remove the unused ProcessedPage import from the integration test to satisfy Ruff linting
- document the lint cleanup in PLAN.md's recent updates section

## Testing
- uv run ruff check

------
https://chatgpt.com/codex/tasks/task_e_68dfb1b6a2948323a37b7c1396d55138