### PR TITLE
Tighten synthesis typing to satisfy mypy

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -52,6 +52,8 @@
 - [x] Added a synthesis stage that orders assessed pages by prompt fit and technical depth, then prompts the LLM for a sourced final answer (October 3, 2025).
 - [x] Ensured console and JSON outputs list pages in the same relevance order used during final answer synthesis (October 3, 2025).
 - [x] Implemented a three-day page cache with an optional CLI refresh flag to skip cache hits when required (October 3, 2025).
+- [x] Removed an unused integration-test import flagged by CI linting to keep the suite clean (October 3, 2025).
+- [x] Tightened type coverage by adding a protocol-aware synthesis client abstraction, normalizing cached path handling, and casting the OpenAI client only at the CLI boundary to satisfy mypy (October 3, 2025).
 
 ## Next Steps
 
@@ -61,6 +63,7 @@
 4. [x] Audit remaining modules for `collections.abc` usage to ensure consistency with modern type hints (confirmed only `main.py` and integration tests import `Iterable` from `collections.abc`).
 5. [ ] Expose cache TTL and artifact directory overrides via CLI flags to support varied research horizons and storage layouts.
 6. [ ] Add cache hit/miss metrics and periodic cleanup of expired entries for long-lived research runs.
+7. [ ] Explore wrapping the OpenAI client in a thin adapter that implements `SynthesisClient` explicitly, eliminating the cast in `main.py`.
 
 ## New Features
 

--- a/src/scolar/cache.py
+++ b/src/scolar/cache.py
@@ -85,8 +85,13 @@ class PageCache:
     ) -> None:
         page_dict = page_to_dict(page)
         markdown_path_raw = page_dict.get("markdown_path")
-        if markdown_path_raw:
+        path_obj: Path | None = None
+        if isinstance(markdown_path_raw, Path):
+            path_obj = markdown_path_raw
+        elif isinstance(markdown_path_raw, str) and markdown_path_raw:
             path_obj = Path(markdown_path_raw)
+
+        if path_obj is not None:
             try:
                 relative = path_obj.relative_to(self._settings.output_dir)
                 page_dict["markdown_path"] = str(relative)

--- a/src/scolar/main.py
+++ b/src/scolar/main.py
@@ -7,11 +7,12 @@ import logging
 import sys
 from collections.abc import Iterable
 from pathlib import Path
+from typing import cast
 
 import httpx
 from openai import AsyncOpenAI
 
-from .answer import SynthesisResult, synthesize_answer
+from .answer import SynthesisClient, SynthesisResult, synthesize_answer
 from .config import load_settings
 from .pipeline import ProcessedPage, gather_pages
 from .report import build_json_record, render_report
@@ -107,7 +108,7 @@ async def run_async(args: argparse.Namespace) -> int:
             )
             if results:
                 synthesis = await synthesize_answer(
-                    llm_client,
+                    cast(SynthesisClient, llm_client),
                     settings,
                     args.prompt,
                     results,

--- a/src/scolar/pipeline.py
+++ b/src/scolar/pipeline.py
@@ -108,7 +108,7 @@ async def gather_pages(
     if tasks:
         completed = await asyncio.gather(*tasks, return_exceptions=True)
         for url, outcome in zip(task_urls, completed, strict=False):
-            if isinstance(outcome, Exception):
+            if isinstance(outcome, BaseException):
                 logger.error("Unhandled error processing URL %s", url, exc_info=outcome)
                 continue
             if outcome:

--- a/tests/test_answer.py
+++ b/tests/test_answer.py
@@ -23,14 +23,18 @@ class _FakeResponses:
         self.payload = payload
         self.calls: list[dict] = []
 
-    async def create(self, **kwargs) -> _FakeLLMResponse:  # noqa: ANN003, ANN204
+    async def create(self, **kwargs: object) -> _FakeLLMResponse:  # noqa: ANN204
         self.calls.append(kwargs)
         return _FakeLLMResponse(output_text=self.payload)
 
 
 class _FakeLLMClient:
     def __init__(self, payload: str) -> None:
-        self.responses = _FakeResponses(payload)
+        self._responses = _FakeResponses(payload)
+
+    @property
+    def responses(self) -> _FakeResponses:
+        return self._responses
 
 
 def _settings(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,7 +21,7 @@ from scolar.models import (
     RecommendedLink,
     Score,
 )
-from scolar.pipeline import ProcessedPage, gather_pages
+from scolar.pipeline import gather_pages
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- remove the unused ProcessedPage import from the integration test to satisfy Ruff linting
- document the lint cleanup in PLAN.md's recent updates section
- introduce a synthesis client protocol, normalize cached markdown paths, and cast the CLI OpenAI client to meet mypy expectations
- refresh the answer synthesis tests and planning doc to reflect the stricter typing changes

## Testing
- uv run ruff check
- uv run mypy src tests

------
https://chatgpt.com/codex/tasks/task_e_68dfb1b6a2948323a37b7c1396d55138